### PR TITLE
Fix bug with the use of contributor_id field and some improvements

### DIFF
--- a/src/wisewords_backend/Cargo.toml
+++ b/src/wisewords_backend/Cargo.toml
@@ -14,3 +14,4 @@ ic-cdk = "0.11.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 ic-stable-structures = "0.5.6"
+validator = { version = "0.15", features = ["derive"] }

--- a/src/wisewords_backend/src/lib.rs
+++ b/src/wisewords_backend/src/lib.rs
@@ -1,19 +1,20 @@
 #[macro_use]
 extern crate serde;
-use candid::{Decode, Encode};
-use ic_cdk::api::time;
+use candid::{Decode, Encode, Principal};
+use ic_cdk::api::{caller, time};
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
 use ic_stable_structures::{BoundedStorable, Cell, DefaultMemoryImpl, StableBTreeMap, Storable};
-use std::{borrow::Cow, cell::RefCell};
 use std::cmp::Reverse;
-
+use std::{borrow::Cow, cell::RefCell};
+use validator::Validate;
 
 type Memory = VirtualMemory<DefaultMemoryImpl>;
 type IdCell = Cell<u64, Memory>;
 
-#[derive(candid::CandidType, Clone, Serialize, Deserialize, Default)]
+#[derive(candid::CandidType, Clone, Serialize, Deserialize)]
 struct Contributor {
     id: u64,
+    user_principal: Principal,
     username: String,
     email: String,
     age: u32,
@@ -37,20 +38,18 @@ impl BoundedStorable for Contributor {
     const IS_FIXED_SIZE: bool = false;
 }
 
-
 #[derive(candid::CandidType, Clone, Serialize, Deserialize, Default)]
 struct Quote {
-    id:u64,
-    contributor_id:u64,
-    author:String,
-    text:String,
-    category:String,
-    created_at:u64,
-    updated_at:Option<u64>
-
+    id: u64,
+    contributor_id: u64,
+    author: String,
+    text: String,
+    category: String,
+    created_at: u64,
+    updated_at: Option<u64>,
 }
 
-// Implement Storable and BoundedStorable traits for Quote 
+// Implement Storable and BoundedStorable traits for Quote
 impl Storable for Quote {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
         Cow::Owned(Encode!(self).unwrap())
@@ -65,8 +64,6 @@ impl BoundedStorable for Quote {
     const MAX_SIZE: u32 = 1024;
     const IS_FIXED_SIZE: bool = false;
 }
-
-
 
 thread_local! {
     static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> = RefCell::new(
@@ -90,43 +87,48 @@ thread_local! {
         RefCell::new(StableBTreeMap::init(
             MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(3)))
     ));
-    
+
 }
 
-#[derive(candid::CandidType, Serialize, Deserialize, Default)]
+#[derive(candid::CandidType, Serialize, Deserialize, Default, Validate)]
 struct ContributorPayload {
+    #[validate(length(min = 3))]
     username: String,
     email: String,
+    #[validate(range(min = 18))]
     age: u32,
 }
 
-#[derive(candid::CandidType, Serialize, Deserialize, Default)]
+#[derive(candid::CandidType, Serialize, Deserialize, Default, Validate)]
 struct QuotePayload {
-    contributor_id:u64,
-    author:String,
-    text:String,
-    category:String,
+    contributor_id: u64,
+    author: String,
+    #[validate(length(min = 1))]
+    text: String,
+    #[validate(length(min = 3))]
+    category: String,
 }
-
-
 
 // Contributer CRUD
 
 // get all contributors
 #[ic_cdk::query]
-fn get_all_contributors() -> Result<Vec<Contributor>, Error>{
-    let contributors_map: Vec<(u64,Contributor)> = CONTRIBUTOR_STORAGE.with(|service| service.borrow().iter().collect());
-    let contributors: Vec<Contributor> = contributors_map.into_iter().map(|(_, contributor)| contributor).collect();
+fn get_all_contributors() -> Result<Vec<Contributor>, Error> {
+    let contributors_map: Vec<(u64, Contributor)> =
+        CONTRIBUTOR_STORAGE.with(|service| service.borrow().iter().collect());
+    let contributors: Vec<Contributor> = contributors_map
+        .into_iter()
+        .map(|(_, contributor)| contributor)
+        .collect();
 
-    if !contributors.is_empty(){
+    if !contributors.is_empty() {
         Ok(contributors)
-    }else {
-        Err(Error::NotFound{
+    } else {
+        Err(Error::NotFound {
             msg: "No contributors found.".to_string(),
         })
     }
 }
-
 
 #[ic_cdk::query]
 fn get_contributor(id: u64) -> Result<Contributor, Error> {
@@ -143,29 +145,47 @@ fn _get_contributor(id: &u64) -> Option<Contributor> {
 }
 
 #[ic_cdk::update]
-fn add_contributor(contrib: ContributorPayload) -> Option<Contributor> {
+fn add_contributor(contrib: ContributorPayload) -> Result<Contributor, Error> {
+    let check_payload = contrib.validate();
+    if check_payload.is_err() {
+        return Err(Error::ValidationFailed {
+            content: check_payload.err().unwrap().to_string(),
+        });
+    }
     let id = CONTRIBUTOR_ID_COUNTER
         .with(|counter| {
             let current_value = *counter.borrow().get();
             counter.borrow_mut().set(current_value + 1)
         })
         .expect("cannot increment id counter");
-    let contributor = Contributor{ 
-        id, 
+    let contributor = Contributor {
+        id,
+        user_principal: caller(),
         username: contrib.username,
         email: contrib.email,
-        age: contrib.age, 
-        created_at: time(), 
-        updated_at: None 
+        age: contrib.age,
+        created_at: time(),
+        updated_at: None,
     };
     do_insert_contributor(&contributor);
-    Some(contributor)
+    Ok(contributor)
 }
 
 #[ic_cdk::update]
 fn update_contributor(id: u64, payload: ContributorPayload) -> Result<Contributor, Error> {
+    let check_payload = payload.validate();
+    if check_payload.is_err() {
+        return Err(Error::ValidationFailed {
+            content: check_payload.err().unwrap().to_string(),
+        });
+    }
     match CONTRIBUTOR_STORAGE.with(|service| service.borrow().get(&id)) {
         Some(mut contributor) => {
+            // Validates whether caller is the owner
+            let check_if_owner = _check_if_owner(&contributor);
+            if check_if_owner.is_err() {
+                return Err(check_if_owner.err().unwrap());
+            }
             contributor.username = payload.username;
             contributor.email = payload.email;
             contributor.age = payload.age;
@@ -184,11 +204,22 @@ fn update_contributor(id: u64, payload: ContributorPayload) -> Result<Contributo
 
 // helper method to perform insert.
 fn do_insert_contributor(contributor: &Contributor) {
-    CONTRIBUTOR_STORAGE.with(|service| service.borrow_mut().insert(contributor.id, contributor.clone()));
+    CONTRIBUTOR_STORAGE.with(|service| {
+        service
+            .borrow_mut()
+            .insert(contributor.id, contributor.clone())
+    });
 }
 
 #[ic_cdk::update]
 fn delete_contributor(id: u64) -> Result<Contributor, Error> {
+    let contributor =
+        _get_contributor(&id).expect(&format!("couldn't find a contributor with id={}", id));
+    // Validates whether caller is the owner
+    let check_if_owner = _check_if_owner(&contributor);
+    if check_if_owner.is_err() {
+        return Err(check_if_owner.err().unwrap());
+    }
     match CONTRIBUTOR_STORAGE.with(|service| service.borrow_mut().remove(&id)) {
         Some(contributor) => Ok(contributor),
         None => Err(Error::NotFound {
@@ -200,24 +231,22 @@ fn delete_contributor(id: u64) -> Result<Contributor, Error> {
     }
 }
 
-
 // Qoutes
 
-
 #[ic_cdk::query]
-fn get_all_quotes() -> Result<Vec<Quote>, Error>{
-    let quotes_map: Vec<(u64,Quote)> = QUOTE_STORAGE.with(|service| service.borrow().iter().collect());
+fn get_all_quotes() -> Result<Vec<Quote>, Error> {
+    let quotes_map: Vec<(u64, Quote)> =
+        QUOTE_STORAGE.with(|service| service.borrow().iter().collect());
     let quotes: Vec<Quote> = quotes_map.into_iter().map(|(_, quote)| quote).collect();
 
-    if !quotes.is_empty(){
+    if !quotes.is_empty() {
         Ok(quotes)
-    }else {
-        Err(Error::NotFound{
+    } else {
+        Err(Error::NotFound {
             msg: "No quotes found.".to_string(),
         })
     }
 }
-
 
 #[ic_cdk::query]
 fn get_quote(id: u64) -> Result<Quote, Error> {
@@ -233,18 +262,15 @@ fn _get_quote(id: &u64) -> Option<Quote> {
     QUOTE_STORAGE.with(|service| service.borrow().get(id))
 }
 
-
-// get recent quotes that were created eg: the last five 
+// get recent quotes that were created eg: the last five
 
 #[ic_cdk::query]
 fn get_recent_quotes() -> Result<Vec<Quote>, Error> {
-    let quotes_map: Vec<(u64,Quote)> = QUOTE_STORAGE.with(|service| service.borrow().iter().collect());
+    let quotes_map: Vec<(u64, Quote)> =
+        QUOTE_STORAGE.with(|service| service.borrow().iter().collect());
 
     // Sort the quotes by created_at timestamp in reverse order to get the most recent ones first
-    let mut sorted_quotes: Vec<Quote> = quotes_map
-        .into_iter()
-        .map(|(_, quote)| quote)
-        .collect();
+    let mut sorted_quotes: Vec<Quote> = quotes_map.into_iter().map(|(_, quote)| quote).collect();
     sorted_quotes.sort_by_key(|quote| Reverse(quote.created_at));
 
     // Take the first 5 quotes (the most recent ones)
@@ -259,59 +285,88 @@ fn get_recent_quotes() -> Result<Vec<Quote>, Error> {
     }
 }
 
+// Function to get quotes by a specified category
 
-  // Function to get quotes by a specified category
+#[ic_cdk::query]
+fn get_quotes_by_category(category: String) -> Result<Vec<Quote>, Error> {
+    let quotes_map: Vec<(u64, Quote)> =
+        QUOTE_STORAGE.with(|service| service.borrow().iter().collect());
 
-  #[ic_cdk::query]
-  fn get_quotes_by_category(category: String) -> Result<Vec<Quote>, Error> {
-    let quotes_map: Vec<(u64,Quote)> = QUOTE_STORAGE.with(|service| service.borrow().iter().collect());
+    // Filter quotes by the provided category (case insensitive)
+    let quotes_in_category: Vec<Quote> = quotes_map
+        .into_iter()
+        .map(|(_, quote)| quote)
+        .filter(|quote| quote.category.to_lowercase() == category.to_lowercase())
+        .collect();
 
-      
-      // Filter quotes by the provided category (case insensitive)
-      let quotes_in_category: Vec<Quote> = quotes_map
-          .into_iter()
-          .map(|(_, quote)| quote)
-          .filter(|quote| quote.category.to_lowercase() == category.to_lowercase())
-          .collect();
-  
-      if !quotes_in_category.is_empty() {
-          Ok(quotes_in_category)
-      } else {
-          Err(Error::NotFound {
-              msg: format!("No quotes found in category: {}", category),
-          })
-      }
-  }
-  
-
+    if !quotes_in_category.is_empty() {
+        Ok(quotes_in_category)
+    } else {
+        Err(Error::NotFound {
+            msg: format!("No quotes found in category: {}", category),
+        })
+    }
+}
 
 #[ic_cdk::update]
 
-fn add_quote(quotepayload: QuotePayload) -> Option<Quote> {
+fn add_quote(quotepayload: QuotePayload) -> Result<Quote, Error> {
+    let check_payload = quotepayload.validate();
+    if check_payload.is_err() {
+        return Err(Error::ValidationFailed {
+            content: check_payload.err().unwrap().to_string(),
+        });
+    }
+    let contributor = _get_contributor(&quotepayload.contributor_id).expect(&format!(
+        "couldn't find a contributor with id={}",
+        quotepayload.contributor_id
+    ));
+    let check_if_owner = _check_if_owner(&contributor);
+    if check_if_owner.is_err() {
+        return Err(check_if_owner.err().unwrap());
+    }
     let id = QUOTE_ID_COUNTER
         .with(|counter| {
             let current_value = *counter.borrow().get();
             counter.borrow_mut().set(current_value + 1)
         })
         .expect("cannot increment id counter");
-    let quote = Quote { 
+    let quote = Quote {
         id,
-        contributor_id: quotepayload.contributor_id, 
-        author: quotepayload.author, 
-        text: quotepayload.text, 
-        category: quotepayload.category, 
-        created_at: time(), 
-        updated_at: None 
+        contributor_id: quotepayload.contributor_id,
+        author: quotepayload.author,
+        text: quotepayload.text,
+        category: quotepayload.category,
+        created_at: time(),
+        updated_at: None,
     };
     do_insert_quote(&quote);
-    Some(quote)
+    Ok(quote)
 }
-
 
 #[ic_cdk::update]
 fn update_quote(id: u64, payload: QuotePayload) -> Result<Quote, Error> {
+    let check_payload = payload.validate();
+    if check_payload.is_err() {
+        return Err(Error::ValidationFailed {
+            content: check_payload.err().unwrap().to_string(),
+        });
+    }
     match QUOTE_STORAGE.with(|service| service.borrow().get(&id)) {
         Some(mut quote) => {
+            let contributor = _get_contributor(&quote.contributor_id).expect(&format!(
+                "couldn't find a contributor with id={}",
+                quote.contributor_id
+            ));
+            let check_if_owner = _check_if_owner(&contributor);
+            if check_if_owner.is_err() {
+                return Err(check_if_owner.err().unwrap());
+            }
+            // ensures that the new contributor_id is an id that is valid
+            assert!(
+                _get_contributor(&payload.contributor_id).is_some(),
+                "Invalid new contributor id"
+            );
             quote.contributor_id = payload.contributor_id;
             quote.author = payload.author;
             quote.text = payload.text;
@@ -321,23 +376,39 @@ fn update_quote(id: u64, payload: QuotePayload) -> Result<Quote, Error> {
             Ok(quote)
         }
         None => Err(Error::NotFound {
-            msg: format!(
-                "couldn't update a Quote with id={}. Quote not found",
-                id
-            ),
+            msg: format!("couldn't update a Quote with id={}. Quote not found", id),
         }),
     }
 }
-
 
 // helper method to perform insert.
 fn do_insert_quote(quote: &Quote) {
     QUOTE_STORAGE.with(|service| service.borrow_mut().insert(quote.id, quote.clone()));
 }
 
+// Helper function to check whether the caller is the owner of the contributor profile
+fn _check_if_owner(contributor: &Contributor) -> Result<(), Error> {
+    if contributor.user_principal.to_string() != caller().to_string() {
+        return Err(Error::AuthenticationFailed {
+            msg: format!(
+                "Caller={} isn't the owner of the contributor with id={}",
+                caller(),
+                contributor.id
+            ),
+        });
+    } else {
+        Ok(())
+    }
+}
 
 #[ic_cdk::update]
 fn delete_quote(id: u64) -> Result<Quote, Error> {
+    let contributor =
+        _get_contributor(&id).expect(&format!("couldn't find a contributor with id={}", id));
+    let check_if_owner = _check_if_owner(&contributor);
+    if check_if_owner.is_err() {
+        return Err(check_if_owner.err().unwrap());
+    }
     match QUOTE_STORAGE.with(|service| service.borrow_mut().remove(&id)) {
         Some(quote) => Ok(quote),
         None => Err(Error::NotFound {
@@ -349,13 +420,12 @@ fn delete_quote(id: u64) -> Result<Quote, Error> {
     }
 }
 
-
 #[derive(candid::CandidType, Deserialize, Serialize)]
 enum Error {
     NotFound { msg: String },
+    ValidationFailed { content: String },
+    AuthenticationFailed { msg: String },
 }
-
-
 
 // need this to generate candid
 ic_cdk::export_candid!();

--- a/src/wisewords_backend/src/lib.rs
+++ b/src/wisewords_backend/src/lib.rs
@@ -14,7 +14,7 @@ type IdCell = Cell<u64, Memory>;
 #[derive(candid::CandidType, Clone, Serialize, Deserialize)]
 struct Contributor {
     id: u64,
-    user_principal: Principal,
+    contributor_principal: Principal,
     username: String,
     email: String,
     age: u32,
@@ -160,7 +160,7 @@ fn add_contributor(contrib: ContributorPayload) -> Result<Contributor, Error> {
         .expect("cannot increment id counter");
     let contributor = Contributor {
         id,
-        user_principal: caller(),
+        contributor_principal: caller(),
         username: contrib.username,
         email: contrib.email,
         age: contrib.age,
@@ -388,7 +388,7 @@ fn do_insert_quote(quote: &Quote) {
 
 // Helper function to check whether the caller is the owner of the contributor profile
 fn _check_if_owner(contributor: &Contributor) -> Result<(), Error> {
-    if contributor.user_principal.to_string() != caller().to_string() {
+    if contributor.contributor_principal.to_string() != caller().to_string() {
         return Err(Error::AuthenticationFailed {
             msg: format!(
                 "Caller={} isn't the owner of the contributor with id={}",

--- a/src/wisewords_backend/wisewords_backend.did
+++ b/src/wisewords_backend/wisewords_backend.did
@@ -1,13 +1,18 @@
 type Contributor = record {
   id : nat64;
   age : nat32;
+  contributor_principal : principal;
   updated_at : opt nat64;
   username : text;
   created_at : nat64;
   email : text;
 };
 type ContributorPayload = record { age : nat32; username : text; email : text };
-type Error = variant { NotFound : record { msg : text } };
+type Error = variant {
+  ValidationFailed : record { content : text };
+  NotFound : record { msg : text };
+  AuthenticationFailed : record { msg : text };
+};
 type Quote = record {
   id : nat64;
   updated_at : opt nat64;
@@ -28,8 +33,8 @@ type Result_1 = variant { Ok : Quote; Err : Error };
 type Result_2 = variant { Ok : vec Contributor; Err : Error };
 type Result_3 = variant { Ok : vec Quote; Err : Error };
 service : {
-  add_contributor : (ContributorPayload) -> (opt Contributor);
-  add_quote : (QuotePayload) -> (opt Quote);
+  add_contributor : (ContributorPayload) -> (Result);
+  add_quote : (QuotePayload) -> (Result_1);
   delete_contributor : (nat64) -> (Result);
   delete_quote : (nat64) -> (Result_1);
   get_all_contributors : () -> (Result_2) query;


### PR DESCRIPTION
## Improvements and Fixes

1. Implemented input validations to ensure that the input data is not invalid values such as empty strings and meets certain criteria, for example, the age of contributors should be at least 18 years old(can be adjusted based on the need of the platform).
2. Implemented authentication checks and added a contributor_principal field to ensure that only the owner of a contributor profile can delete or update his profile
3. Implemented authentication checks around the update and delete functions for quotes to ensure that only the contributor/owner of a quote can delete or update the quote.
4. Implemented checks when creating or updating a quote to ensure that the contributor_id used references to an existing and valid contributor profile. The check also ensures that the caller is the owner of that profile to prevent issues such as impersonation.